### PR TITLE
chore: updates zksync-era dep and revm to latest 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 
-revm = { git = "https://github.com/dutterbutter/revm.git", branch = "release_v26_with_old_sha" }
+revm = { git = "https://github.com/dutterbutter/revm.git", branch = "db/release_v26_sha3_0.10.6" }
 #revm = { version = "2.3", default-features = false, features = [
 #  "std",
 #  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 
-revm = { git = "https://github.com/mm-zk/revm.git", branch = "release_v25_with_old_sha" }
+revm = { git = "https://github.com/dutterbutter/revm.git", branch = "release_v26_with_old_sha" }
 #revm = { version = "2.3", default-features = false, features = [
 #  "std",
 #  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"
 eyre = "0.6"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "time", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,3 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"
 eyre = "0.6"
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "time", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 
-#revm = { path = "../revm/crates/revm" }
 revm = { git = "https://github.com/mm-zk/revm.git", branch = "release_v25_with_old_sha" }
 #revm = { version = "2.3", default-features = false, features = [
 #  "std",
@@ -17,20 +16,14 @@ revm = { git = "https://github.com/mm-zk/revm.git", branch = "release_v25_with_o
 #  "optional_eip3607"
 #] }
 
-# era_test_node = { path = "../era-test-node"}
-era_test_node = {git = "https://github.com/matter-labs/era-test-node.git", rev = "8013425569340833d4177526850fb517c604bc49"}
-
-# zksync_basic_types = {path = "../zksync-era/core/lib/basic_types"}
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-
-#zksync_types = {path = "../zksync-era/core/lib/types"}
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-vm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "a98e454221da7d6ecad9b317cf44b0786e819659" }
-
+era_test_node = {git = "https://github.com/matter-labs/era-test-node.git", branch = "db/update-to-latest" }
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+zk_evm = {git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc1"}
 
 ethabi = "18.0.0"
-zk_evm = {git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc0"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"

--- a/src/conversion_utils.rs
+++ b/src/conversion_utils.rs
@@ -1,15 +1,15 @@
 /// Conversion between REVM units and zkSync units.
 use revm::primitives::U256 as revmU256;
-use revm::primitives::{B160, B256};
+use revm::primitives::{Address, B256};
 
 use zksync_basic_types::{H160, H256, U256};
 use zksync_utils::h256_to_u256;
 
-pub fn b160_to_h160(i: B160) -> H160 {
-    i.as_fixed_bytes().into()
+pub fn address_to_h160(i: Address) -> H160 {
+    H160::from(i.0 .0)
 }
 
-pub fn h160_to_b160(i: H160) -> B160 {
+pub fn h160_to_address(i: H160) -> Address {
     i.as_fixed_bytes().into()
 }
 
@@ -55,10 +55,10 @@ mod test {
 
     #[test]
     fn test_160_conversion() {
-        let b = B160::from_str("0x000000000000000000000000000000000000800b").unwrap();
-        let h = b160_to_h160(b);
+        let b = Address::from_str("0x000000000000000000000000000000000000800b").unwrap();
+        let h = address_to_h160(b);
         assert_eq!(h.to_string(), "0x0000…800b");
-        let b2 = h160_to_b160(h);
+        let b2 = h160_to_address(h);
         assert_eq!(b, b2);
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -189,4 +189,59 @@ where
     fn get_transaction_by_hash(&self, _hash: H256) -> eyre::Result<Option<Transaction>> {
         todo!()
     }
+
+    fn get_transaction_details(&self, _hash: H256) -> eyre::Result<Option<Transaction>> {
+        todo!()
+    }
+
+    fn get_block_by_hash(
+            &self,
+            hash: H256,
+            full_transactions: bool,
+        ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
+            todo!()
+    }
+
+    fn get_block_by_number(
+            &self,
+            block_number: zksync_types::api::BlockNumber,
+            full_transactions: bool,
+        ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
+        todo!()
+    }
+
+    fn get_block_details(&self, miniblock: MiniblockNumber) -> eyre::Result<Option<zksync_types::api::BlockDetails>> {
+        todo!()
+    }
+
+    fn get_block_transaction_count_by_hash(&self, block_hash: H256) -> eyre::Result<Option<U256>> {
+        todo!()
+    }
+
+    fn get_block_transaction_count_by_number(
+            &self,
+            block_number: zksync_types::api::BlockNumber,
+        ) -> eyre::Result<Option<U256>> {
+        todo!()
+    }
+
+    fn get_transaction_by_block_hash_and_index(
+            &self,
+            block_hash: H256,
+            index: zksync_basic_types::web3::types::Index,
+        ) -> eyre::Result<Option<Transaction>> {
+        todo!()
+    }
+
+    fn get_transaction_by_block_number_and_index(
+            &self,
+            block_number: zksync_types::api::BlockNumber,
+            index: zksync_basic_types::web3::types::Index,
+        ) -> eyre::Result<Option<Transaction>> {
+        todo!()
+    }
+
+    fn get_bridge_contracts(&self) -> eyre::Result<zksync_types::api::BridgeAddresses> {
+        todo!()
+    }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -197,50 +197,50 @@ where
 
     fn get_block_by_hash(
         &self,
-        hash: H256,
-        full_transactions: bool,
+        _hash: H256,
+        _full_transactions: bool,
     ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
         todo!()
     }
 
     fn get_block_by_number(
         &self,
-        block_number: zksync_types::api::BlockNumber,
-        full_transactions: bool,
+        _block_number: zksync_types::api::BlockNumber,
+        _full_transactions: bool,
     ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
         todo!()
     }
 
     fn get_block_details(
         &self,
-        miniblock: MiniblockNumber,
+        _miniblock: MiniblockNumber,
     ) -> eyre::Result<Option<zksync_types::api::BlockDetails>> {
         todo!()
     }
 
-    fn get_block_transaction_count_by_hash(&self, block_hash: H256) -> eyre::Result<Option<U256>> {
+    fn get_block_transaction_count_by_hash(&self, _block_hash: H256) -> eyre::Result<Option<U256>> {
         todo!()
     }
 
     fn get_block_transaction_count_by_number(
         &self,
-        block_number: zksync_types::api::BlockNumber,
+        _block_number: zksync_types::api::BlockNumber,
     ) -> eyre::Result<Option<U256>> {
         todo!()
     }
 
     fn get_transaction_by_block_hash_and_index(
         &self,
-        block_hash: H256,
-        index: zksync_basic_types::web3::types::Index,
+        _block_hash: H256,
+        _index: zksync_basic_types::web3::types::Index,
     ) -> eyre::Result<Option<Transaction>> {
         todo!()
     }
 
     fn get_transaction_by_block_number_and_index(
         &self,
-        block_number: zksync_types::api::BlockNumber,
-        index: zksync_basic_types::web3::types::Index,
+        _block_number: zksync_types::api::BlockNumber,
+        _index: zksync_basic_types::web3::types::Index,
     ) -> eyre::Result<Option<Transaction>> {
         todo!()
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -12,6 +12,7 @@ use std::{
 
 use crate::conversion_utils::{h256_to_b256, h256_to_h160};
 use era_test_node::fork::ForkSource;
+use eyre::ErrReport;
 use revm::{
     primitives::{Bytecode, Bytes},
     Database,
@@ -24,7 +25,6 @@ use zksync_types::{
     StorageKey, ACCOUNT_CODE_STORAGE_ADDRESS, L2_ETH_TOKEN_ADDRESS, NONCE_HOLDER_ADDRESS,
     SYSTEM_CONTEXT_ADDRESS,
 };
-use eyre::ErrReport;
 
 use zksync_utils::{address_to_h256, h256_to_u256, u256_to_h256};
 
@@ -113,12 +113,10 @@ where
                 let u8_bytecode: Vec<u8> = v
                     .iter()
                     .flat_map(|x| u256_to_h256(x.clone()).to_fixed_bytes())
-                    //.cloned()
                     .collect();
 
                 return Some(Bytecode {
                     bytecode: Bytes::copy_from_slice(&u8_bytecode.as_slice()),
-                    // hash: h256_to_b256(u256_to_h256(*k)),
                     state: revm::primitives::BytecodeState::Raw,
                 });
             }
@@ -191,27 +189,33 @@ where
         todo!()
     }
 
-    fn get_transaction_details(&self, _hash: H256) -> Result<std::option::Option<TransactionDetails>, ErrReport> {
+    fn get_transaction_details(
+        &self,
+        _hash: H256,
+    ) -> Result<std::option::Option<TransactionDetails>, ErrReport> {
         todo!()
     }
 
     fn get_block_by_hash(
-            &self,
-            hash: H256,
-            full_transactions: bool,
-        ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
-            todo!()
-    }
-
-    fn get_block_by_number(
-            &self,
-            block_number: zksync_types::api::BlockNumber,
-            full_transactions: bool,
-        ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
+        &self,
+        hash: H256,
+        full_transactions: bool,
+    ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
         todo!()
     }
 
-    fn get_block_details(&self, miniblock: MiniblockNumber) -> eyre::Result<Option<zksync_types::api::BlockDetails>> {
+    fn get_block_by_number(
+        &self,
+        block_number: zksync_types::api::BlockNumber,
+        full_transactions: bool,
+    ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
+        todo!()
+    }
+
+    fn get_block_details(
+        &self,
+        miniblock: MiniblockNumber,
+    ) -> eyre::Result<Option<zksync_types::api::BlockDetails>> {
         todo!()
     }
 
@@ -220,25 +224,25 @@ where
     }
 
     fn get_block_transaction_count_by_number(
-            &self,
-            block_number: zksync_types::api::BlockNumber,
-        ) -> eyre::Result<Option<U256>> {
+        &self,
+        block_number: zksync_types::api::BlockNumber,
+    ) -> eyre::Result<Option<U256>> {
         todo!()
     }
 
     fn get_transaction_by_block_hash_and_index(
-            &self,
-            block_hash: H256,
-            index: zksync_basic_types::web3::types::Index,
-        ) -> eyre::Result<Option<Transaction>> {
+        &self,
+        block_hash: H256,
+        index: zksync_basic_types::web3::types::Index,
+    ) -> eyre::Result<Option<Transaction>> {
         todo!()
     }
 
     fn get_transaction_by_block_number_and_index(
-            &self,
-            block_number: zksync_types::api::BlockNumber,
-            index: zksync_basic_types::web3::types::Index,
-        ) -> eyre::Result<Option<Transaction>> {
+        &self,
+        block_number: zksync_types::api::BlockNumber,
+        index: zksync_basic_types::web3::types::Index,
+    ) -> eyre::Result<Option<Transaction>> {
         todo!()
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -100,7 +100,6 @@ where
 
             return Some(Bytecode {
                 bytecode: Bytes::copy_from_slice(&u8_bytecode.as_slice()),
-                // hash: h256_to_b256(new_bytecode_hash),
                 state: revm::primitives::BytecodeState::Raw,
             });
         }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1,4 +1,4 @@
-use era_test_node::{fork::ForkDetails, node::InMemoryNode, system_contracts};
+use era_test_node::{fork::ForkDetails, node::{InMemoryNode, InMemoryNodeConfig, ShowCalls, ShowStorageLogs, ShowVMDetails, ShowGasDetails}, system_contracts};
 use multivm::interface::VmExecutionResultAndLogs;
 use revm::{
     primitives::{
@@ -173,8 +173,15 @@ where
         // Make sure that l1 gas price is set to reasonable values.
         l1_gas_price: u64::max(env.block.basefee.to::<u64>(), 1000),
     };
-
-    let node = InMemoryNode::new(Some(fork_details), None, Default::default());
+    let config = InMemoryNodeConfig {
+        show_calls: ShowCalls::None,
+        show_storage_logs: ShowStorageLogs::None,
+        show_vm_details: ShowVMDetails::None,
+        show_gas_details: ShowGasDetails::None,
+        resolve_hashes: false,  
+        system_contracts_options: system_contracts::Options::BuiltInWithoutSecurity,
+    };
+    let node = InMemoryNode::new(Some(fork_details), None, config);
 
     let l2_tx = tx_env_to_era_tx(env.tx.clone(), nonces);
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -156,6 +156,7 @@ where
     env.block.number = u256_to_revm_u256(U256::from(num));
     env.block.timestamp = u256_to_revm_u256(U256::from(ts));
 
+    println!("*** chain_id: {:?}", env.cfg.chain_id);
     let chain_id_u32 = if env.cfg.chain_id <= u32::MAX as u64 {
         env.cfg.chain_id as u32
     } else {
@@ -170,7 +171,7 @@ where
         l2_miniblock: num,
         l2_miniblock_hash: Default::default(),
         block_timestamp: ts,
-        overwrite_chain_id: Some(L2ChainId::from(chain_id_u32)),
+        overwrite_chain_id: None,
         // Make sure that l1 gas price is set to reasonable values.
         l1_gas_price: u64::max(env.block.basefee.to::<u64>(), 1000),
     };

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -161,7 +161,8 @@ where
         // TODO: FIXME
         u32::default()
     };
-
+    println!("*** Using chain_id: {:?}", chain_id_u32);
+    println!("CHAINID:::   {:?} ", Some(L2ChainId::from(chain_id_u32)));
     let fork_details = ForkDetails {
         fork_source: &era_db,
         l1_block: L1BatchNumber(num as u32),
@@ -279,6 +280,7 @@ where
             let code_hash = match &account_code {
                 Some(bytecode) => revm_keccak256(bytecode.bytes()),
                 None => {
+                    println!("*** No bytecode for account: {:?}", account);
                     // TODO: FIXME
                     // Handle the case when there's no bytecode
                     KECCAK_EMPTY

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -181,9 +181,9 @@ where
     };
 
     let config = InMemoryNodeConfig {
-        show_calls: ShowCalls::All,
-        show_storage_logs: ShowStorageLogs::All,
-        show_vm_details: ShowVMDetails::All,
+        show_calls: ShowCalls::None,
+        show_storage_logs: ShowStorageLogs::None,
+        show_vm_details: ShowVMDetails::None,
         show_gas_details: ShowGasDetails::None,
         resolve_hashes: false,
         system_contracts_options: system_contracts::Options::BuiltInWithoutSecurity,
@@ -193,6 +193,8 @@ where
     let mut l2_tx = tx_env_to_era_tx(env.tx.clone(), nonces);
 
     if l2_tx.common_data.signature.is_empty() {
+        // FIXME: This is a hack to make sure that the signature is not empty.
+        // Fails without a signature here: https://github.com/matter-labs/zksync-era/blob/73a1e8ff564025d06e02c2689da238ae47bb10c3/core/lib/types/src/transaction_request.rs#L381
         l2_tx.common_data.signature = PackedEthSignature::default().serialize_packed().into();
     }
 
@@ -226,10 +228,7 @@ where
         multivm::interface::ExecutionResult::Halt { .. } => {
             // Need to decide what to do in the case of a halt. This might depend on the reason for the halt.
             // TODO: FIXME
-            revm::primitives::ExecutionResult::Revert {
-                gas_used: env.tx.gas_limit,
-                output: Bytes::new(), // FIXME (function results)
-            }
+            panic!()
         }
     };
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1,4 +1,4 @@
-use era_test_node::{fork::ForkDetails, observability::{Observability, LogLevel}, node::{InMemoryNode, InMemoryNodeConfig, ShowCalls, ShowStorageLogs, ShowVMDetails, ShowGasDetails}, system_contracts};
+use era_test_node::{fork::ForkDetails, node::{InMemoryNode, InMemoryNodeConfig, ShowCalls, ShowStorageLogs, ShowVMDetails, ShowGasDetails}, system_contracts};
 use multivm::interface::VmExecutionResultAndLogs;
 use revm::{
     primitives::{
@@ -7,7 +7,6 @@ use revm::{
     },
     Database,
 };
-use tracing_subscriber::filter::LevelFilter;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -164,7 +163,6 @@ where
         31337
     };
     println!("*** Using chain_id: {:?}", chain_id_u32);
-    println!("CHAINID:::   {:?} ", Some(L2ChainId::from(chain_id_u32)));
     let fork_details = ForkDetails {
         fork_source: &era_db,
         l1_block: L1BatchNumber(num as u32),
@@ -177,11 +175,6 @@ where
         l1_gas_price: u64::max(env.block.basefee.to::<u64>(), 1000),
     };
 
-    let log_level_filter = LevelFilter::from(LogLevel::Debug);
-    let log_file = File::create("./log_era-revm").unwrap();
-
-    // Initialize the tracing subscriber
-    let observability = Observability::init(String::from("era_test_node"), log_level_filter, log_file).unwrap();
     let config = InMemoryNodeConfig {
         show_calls: ShowCalls::All,
         show_storage_logs: ShowStorageLogs::All,
@@ -190,7 +183,7 @@ where
         resolve_hashes: false,  
         system_contracts_options: system_contracts::Options::BuiltInWithoutSecurity,
     };
-    let node = InMemoryNode::new(Some(fork_details), Some(observability), config);
+    let node = InMemoryNode::new(Some(fork_details), None, config);
 
     let l2_tx = tx_env_to_era_tx(env.tx.clone(), nonces);
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -8,10 +8,11 @@ use era_test_node::{fork::ForkDetails, node::InMemoryNode, system_contracts};
 use revm::{
     primitives::{
         Account, AccountInfo, Bytes, EVMResult, Env, Eval, ExecutionResult, HashMap as rHashMap,
-        ResultAndState, StorageSlot, TxEnv, B160,
+        ResultAndState, StorageSlot, TxEnv, Address, keccak256 as revm_keccak256, KECCAK_EMPTY
     },
     Database,
 };
+use zksync_types::api::{Block, BridgeAddresses, Transaction, TransactionVariant};
 use zksync_basic_types::{web3::signing::keccak256, L1BatchNumber, H160, H256, U256};
 use zksync_types::{
     fee::Fee, l2::L2Tx, transaction_request::PaymasterParams, StorageKey, StorageLogQueryType,
@@ -24,7 +25,7 @@ use zksync_utils::{h256_to_account_address, u256_to_h256};
 
 use crate::{
     conversion_utils::{
-        b160_to_h160, h160_to_b160, h256_to_h160, h256_to_revm_u256, revm_u256_to_u256,
+        address_to_h160, h160_to_address, h256_to_h160, h256_to_revm_u256, revm_u256_to_u256,
         u256_to_revm_u256,
     },
     db::RevmDatabaseForEra,
@@ -84,11 +85,11 @@ pub fn tx_env_to_fee(tx_env: &TxEnv) -> Fee {
 pub fn tx_env_to_era_tx(tx_env: TxEnv, nonce: u64) -> L2Tx {
     let mut l2tx = match tx_env.transact_to {
         revm::primitives::TransactTo::Call(contract_address) => L2Tx::new(
-            contract_address.as_fixed_bytes().into(),
+            H160::from(contract_address.0 .0),
             tx_env.data.to_vec(),
             (tx_env.nonce.unwrap_or(nonce) as u32).into(),
             tx_env_to_fee(&tx_env),
-            tx_env.caller.as_fixed_bytes().into(),
+            H160::from(tx_env.caller.0 .0),
             revm_u256_to_u256(tx_env.value),
             None, // factory_deps
             PaymasterParams::default(),
@@ -105,7 +106,7 @@ pub fn tx_env_to_era_tx(tx_env: TxEnv, nonce: u64) -> L2Tx {
                 ),
                 (tx_env.nonce.unwrap_or(nonce) as u32).into(),
                 tx_env_to_fee(&tx_env),
-                tx_env.caller.as_fixed_bytes().into(),
+                H160::from(tx_env.caller.0 .0),
                 revm_u256_to_u256(tx_env.value),
                 Some(packed_bytecode.factory_deps()),
                 PaymasterParams::default(),
@@ -139,7 +140,7 @@ where
 
     let (num, ts) = era_db.block_number_and_timestamp();
 
-    let nonces = era_db.get_nonce_for_address(b160_to_h160(env.tx.caller));
+    let nonces = era_db.get_nonce_for_address(address_to_h160(env.tx.caller));
 
     println!(
         "*** Starting ERA transaction: block: {:?} timestamp: {:?} - but using {:?} and {:?} instead with nonce {:?}",
@@ -155,14 +156,21 @@ where
     env.block.number = u256_to_revm_u256(U256::from(num));
     env.block.timestamp = u256_to_revm_u256(U256::from(ts));
 
+    let chain_id_u32 = if env.cfg.chain_id <= u32::MAX as u64 {
+        env.cfg.chain_id as u32
+    } else {
+        // TODO: FIXME
+        u32::default()
+    };
+
     let fork_details = ForkDetails {
         fork_source: &era_db,
         l1_block: L1BatchNumber(num as u32),
-        l2_block: num,
+        l2_block: Block::default(),
         l2_miniblock: num,
         l2_miniblock_hash: Default::default(),
         block_timestamp: ts,
-        overwrite_chain_id: Some(L2ChainId(env.cfg.chain_id.to::<u16>())),
+        overwrite_chain_id: Some(L2ChainId::from(chain_id_u32)),
         // Make sure that l1 gas price is set to reasonable values.
         l1_gas_price: u64::max(env.block.basefee.to::<u64>(), 1000),
     };
@@ -171,14 +179,6 @@ where
         Some(fork_details),
         None,
         Default::default(),
-        // era_test_node::node::ShowCalls::None,
-        // InMemoryNodeConfig::default(),
-        // era_test_node::node::ShowStorageLogs::None,
-        // era_test_node::node::ShowVMDetails::None,
-        // era_test_node::node::ShowGasDetails::None,
-        // false,
-        // // Disable security on default accounts.
-        // &system_contracts::Options::BuiltInWithoutSecurity,
     );
 
     let l2_tx = tx_env_to_era_tx(env.tx.clone(), nonces);
@@ -190,28 +190,36 @@ where
         )
         .unwrap();
 
-    let (modified_keys, tx_result, _block, bytecodes, _, _) = era_execution_result;
+    let (modified_keys, tx_result, _call_traces, _block, bytecodes, _block_ctx) = era_execution_result;
     let maybe_contract_address = contract_address_from_tx_result(&tx_result);
 
     let execution_result = match tx_result.result {
-        ExecutionResult::Success { output, .. } => {
-            ExecutionResult::Success {
+        multivm::interface::ExecutionResult::Success { output, .. } => {
+            revm::primitives::ExecutionResult::Success {
                 reason: Eval::Return,
                 gas_used: env.tx.gas_limit - tx_result.refunds.gas_refunded as u64,
                 gas_refunded: tx_result.refunds.gas_refunded as u64,
                 logs: vec![],
                 output: revm::primitives::Output::Create(
                     Bytes::new(), // FIXME (function results)
-                    maybe_contract_address.map(|address| h160_to_b160(address)),
+                    maybe_contract_address.map(|address| h160_to_address(address)),
                 ),
             }
-        }
-        ExecutionResult::Revert { .. } | ExecutionResult::Halt { .. } => {
-            ExecutionResult::Revert {
+        },
+        multivm::interface::ExecutionResult::Revert { output, .. } => {
+            revm::primitives::ExecutionResult::Revert {
                 gas_used: env.tx.gas_limit - tx_result.refunds.gas_refunded as u64,
                 output: Bytes::new(), // FIXME (function results)
             }
-        }
+        },
+        multivm::interface::ExecutionResult::Halt { reason, .. } => {
+            // You will need to decide what to do in the case of a halt. This might depend on the reason for the halt.
+            // For now, let's assume you're constructing a Revert with an empty output.
+            revm::primitives::ExecutionResult::Revert {
+                gas_used: env.tx.gas_limit, // assuming full gas usage on halt, adjust as necessary
+                output: Bytes::new(), // FIXME (function results)
+            }
+        },
     };
     
 
@@ -245,10 +253,10 @@ where
         }
     }
 
-    let state: rHashMap<B160, Account> = accounts_touched
+    let state: rHashMap<Address, Account> = accounts_touched
         .iter()
         .map(|account| {
-            let account_b160: B160 = h160_to_b160(*account);
+            let acc: Address = h160_to_address(*account);
 
             let storage: Option<rHashMap<revmU256, StorageSlot>> =
                 account_to_keys.get(account).map(|slot_changes| {
@@ -258,7 +266,7 @@ where
                             (
                                 h256_to_revm_u256(*slot.key()),
                                 StorageSlot {
-                                    original_value: revm::primitives::U256::ZERO, // FIXME
+                                    previous_or_original_value: revm::primitives::U256::ZERO, // FIXME
                                     present_value: h256_to_revm_u256(*value),
                                 },
                             )
@@ -269,23 +277,27 @@ where
             let account_code =
                 era_db.fetch_account_code(account.clone(), &modified_keys, &bytecodes);
 
+            let code_hash = match &account_code {
+                Some(bytecode) => {
+                    revm_keccak256(bytecode.bytes()) 
+                }
+                None => {
+                    // Handle the case when there's no bytecode
+                    KECCAK_EMPTY 
+                }
+            };
+
             (
-                account_b160,
+                acc,
                 Account {
                     info: AccountInfo {
                         balance: revm::primitives::U256::ZERO, // FIXME
                         nonce: era_db.get_nonce_for_address(*account),
-                        code_hash: account_code
-                            .as_ref()
-                            .map(|x| x.hash().clone())
-                            .unwrap_or_default(),
+                        code_hash,
                         code: account_code,
                     },
                     storage: storage.unwrap_or_default(),
-                    storage_cleared: false,
-                    is_destroyed: false,
-                    is_touched: true,
-                    is_not_existing: false,
+                    status: revm::primitives::AccountStatus::LoadedAsNotExisting,
                 },
             )
         })


### PR DESCRIPTION
**Changes introduced in this PR:**
- Updates zksync-era deps to `73a1e8ff564025d06e02c2689da238ae47bb10c3` 
- Updates revm dependency to latest
- Removes deprecated `B160` in favour of `Address` 
- Updates utility conversion to reflect `B160` usage change
- Adds required interface methods (e.g. `get_transaction_details`) 