### PR TITLE
chore: updates era dep to point to era-test-node alpha.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2021"
 [dependencies]
 # Using a fork of revm as zksync-era requires the usage of sha3 0.10.6, and the latest revm uses 0.10.8
 revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6" }
-# TODO: Update to latest era-test-node tag once it is released
-era_test_node = { git = "https://github.com/matter-labs/era-test-node.git", rev = "e9c8ee02da305cd07f69ba6838107c933b3b1b8f" }
+era_test_node = { git = "https://github.com/matter-labs/era-test-node.git", tag = "v0.1.0-alpha.9" }
 zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
 zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
 multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }


### PR DESCRIPTION
Changes introduced in this PR:
- Updates era-test-node dep to point to latest tag 