### PR TITLE
chore: update zksync-era deps and etn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 [dependencies]
 # Using a fork of revm as zksync-era requires the usage of sha3 0.10.6, and the latest revm uses 0.10.8
 revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6" }
-era_test_node = { git = "https://github.com/matter-labs/era-test-node.git", tag = "v0.1.0-alpha.9" }
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+era_test_node = { git = "https://github.com/matter-labs/era-test-node.git", tag = "v0.1.0-alpha.11" }
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
 zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc1"}
 
 ethabi = "18.0.0"


### PR DESCRIPTION
Will keep as **DRAFT** until era-test-node release of `v0.1.0-alpha.11` that includes PR: https://github.com/matter-labs/era-test-node/pull/213.

# What :computer: 
* Updates zksync-era deps to match era-test-node
* Updates era-test-node for _next_ release

# Why :hand:
* The deps need to be aligned between etn, and era-revm
* Requires the _next_ release of era-test-node with this PR: https://github.com/matter-labs/era-test-node/pull/213 which makes `run_l2_tx_inner` public again

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
