### PR TITLE
fix: fixes transaction execution via era-test-node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# Using a fork of revm as zksync-era requires the usage of sha3 0.10.6, and the latest revm uses 0.10.8
-revm = { git = "https://github.com/dutterbutter/revm.git", tag = "sha3_0.10.6" }
-era_test_node = { git = "https://github.com/matter-labs/era-test-node.git", tag = "v0.1.0-alpha.9" }
-zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
-zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "73a1e8ff564025d06e02c2689da238ae47bb10c3" }
+revm = { version = "3.5.0" }
+era_test_node = { git = "https://github.com/matter-labs/era-test-node.git", rev = "a74c39c0d89aec29086524f9a8dd13bf2e4e03f6" }
+zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+multivm = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_web3_decl = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
+zksync_utils = { git = "https://github.com/matter-labs/zksync-era.git", rev = "80273264a9512bc1e6f1d1f4372107f9167260b1" }
 zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc1"}
 
 ethabi = "18.0.0"
@@ -21,3 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"
 eyre = "0.6"
+tracing = { version = "0.1.26", features = ["log"] }
+
+[dev-dependencies]
+maplit = "1.0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,5 @@ pub mod conversion_utils;
 pub mod db;
 pub mod factory_deps;
 pub mod transactions;
+
+mod testing;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,29 @@
+#![cfg(test)]
+
+use revm::primitives::{AccountInfo, Address, Bytecode, B256, U256};
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct MockDatabase {
+    pub basic: HashMap<Address, AccountInfo>,
+}
+
+impl revm::Database for MockDatabase {
+    type Error = String;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        Ok(self.basic.get(&address).cloned())
+    }
+
+    fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+        todo!()
+    }
+
+    fn storage(&mut self, _address: Address, _index: U256) -> Result<U256, Self::Error> {
+        Ok(U256::ZERO)
+    }
+
+    fn block_hash(&mut self, _number: U256) -> Result<B256, Self::Error> {
+        todo!()
+    }
+}


### PR DESCRIPTION
# What :computer: 
* Fixes state not being updated as the touched account state was not set to `Touched`
* Fixes `fetch_account_bytecode` which would panic if bytecode wasn't present in the `bytecodes` data return from the era-test-node but present in the `modified_keys`
* Fixes `get_storage_at` panic caused due to era-test-node producing 2 blocks per transaction
* Simplifies `env.block.number` & `env.block.timestamp` logic.
* Updates era-test-node to latest revision
* Adds tests

# Why :hand:
* The above bugs were causing failures
* Tests for regression

# Evidence :camera:
![image](https://github.com/matter-labs/era-revm/assets/1564843/1e20ed5d-7c1a-4884-9a21-e6863f2613d8)


<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
