### PR TITLE
chore: remove smoke-test debug from ci

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,10 +58,6 @@ jobs:
       run: |
         git clone https://github.com/matter-labs/zkfoundry-smoke-test
         cd zkfoundry-smoke-test
-        git fetch --all 
-        git checkout bf18e30fe928e50066e131878a9583f404aaa0d7
-        git rev-parse HEAD
-        cat smoke-test.sh
         ./smoke-test.sh
 
   cheatcodes:


### PR DESCRIPTION
# What :computer: 
* Removes debug info from ci

# Why :hand:
* Was necessary for smoke test

# Evidence :camera:
Test passes https://github.com/matter-labs/zkfoundry-smoke-test/pull/5

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
