### PR TITLE
chore: update to use vm_latest with era-test-node boojum integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 revm = { version = "3.5.0" }
-era_test_node = { git = "https://github.com/matter-labs/era-test-node.git", rev = "64835d25a6e4b1540a091ff0d805b01227213969" }
+era_test_node = { git = "https://github.com/matter-labs/era-test-node.git", rev = "9e7c5cbbef3366b9f573d480ce3646d8fd4ce5d4" }
 zksync_basic_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "bd268ac02bc3530c1d3247cb9496c3e13c2e52d9" }
 zksync_types = { git = "https://github.com/matter-labs/zksync-era.git", rev = "bd268ac02bc3530c1d3247cb9496c3e13c2e52d9" }
 zksync_state = { git = "https://github.com/matter-labs/zksync-era.git", rev = "bd268ac02bc3530c1d3247cb9496c3e13c2e52d9" }

--- a/src/cheatcodes.rs
+++ b/src/cheatcodes.rs
@@ -1,8 +1,9 @@
 use era_test_node::utils::bytecode_to_factory_dep;
 use ethers::{abi::AbiDecode, prelude::abigen};
-use multivm::interface::dyn_tracers::vm_1_3_3::DynTracer;
-use multivm::vm_refunds_enhancement::{HistoryMode, SimpleMemory, VmTracer};
-use multivm::zk_evm_1_3_3::tracing::{BeforeExecutionData, VmLocalStateData};
+// use multivm::interface::dyn_tracers::vm_1_3_3::DynTracer;
+use multivm::interface::dyn_tracers::vm_1_4_0::DynTracer;
+use multivm::vm_latest::{HistoryMode, SimpleMemory, VmTracer};
+use multivm::zk_evm_1_4_0::tracing::{BeforeExecutionData, VmLocalStateData};
 use zk_evm::zkevm_opcode_defs::{FatPointer, Opcode, CALL_IMPLICIT_CALLDATA_FAT_PTR_REGISTER};
 use zksync_basic_types::{AccountTreeId, H160};
 use zksync_state::{StoragePtr, WriteStorage};

--- a/src/cheatcodes.rs
+++ b/src/cheatcodes.rs
@@ -1,6 +1,5 @@
 use era_test_node::utils::bytecode_to_factory_dep;
 use ethers::{abi::AbiDecode, prelude::abigen};
-// use multivm::interface::dyn_tracers::vm_1_3_3::DynTracer;
 use multivm::interface::dyn_tracers::vm_1_4_0::DynTracer;
 use multivm::vm_latest::{HistoryMode, SimpleMemory, VmTracer};
 use multivm::zk_evm_1_4_0::tracing::{BeforeExecutionData, VmLocalStateData};

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -5,7 +5,7 @@ use era_test_node::{
     },
     system_contracts,
 };
-use multivm::{interface::VmExecutionResultAndLogs, vm_refunds_enhancement::ToTracerPointer};
+use multivm::{interface::VmExecutionResultAndLogs, vm_latest::ToTracerPointer};
 use revm::{
     primitives::{
         Account, AccountInfo, Address, Bytes, EVMResult, Env, Eval, Halt, HashMap as rHashMap,


### PR DESCRIPTION
Opening as a draft until https://github.com/matter-labs/era-test-node/pull/235 is merged. Will then need to update era-test-node dependency and update foundry-zksync.

# What :computer: 
* Updates to use vm_latest instead of `vm_refunds_enhancement`

# Why :hand:
* Needed for https://github.com/matter-labs/era-test-node/pull/235 once merged

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can uncomment any section applicable to your Pull Request. -->

<!-- # Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code? -->
